### PR TITLE
Also includes AFFINITY-52

### DIFF
--- a/app/Http/Controllers/InterestsController.php
+++ b/app/Http/Controllers/InterestsController.php
@@ -128,9 +128,16 @@ class InterestsController extends Controller
      */
     public function getPersonsResearchInterests($email)
     {
-        $user = User::whereEmail($email)->firstOrFail();
+        $user = User::whereEmail($email)->first();
+        if($user==null)
+        {
+            $response = buildResponseArray('research_interests');
+            $response['count']=0;
+            $response['interests'] = [];
+            return $response;
+        }
 
-        $response = buildResponseArray('interests');
+        $response = buildResponseArray('research_interests');
 
         $interestEntity = InterestEntity::where('entities_id', $user->user_id)->get();
 
@@ -154,8 +161,15 @@ class InterestsController extends Controller
      */
     public function getPersonsPersonalInterests($email)
     {
-        $user = User::whereEmail($email)->firstOrFail();
-        $response = buildResponseArray('interests');
+        $user = User::whereEmail($email)->first();
+        if($user==null)
+        {
+            $response = buildResponseArray('personal_interests');
+            $response['count']=0;
+            $response['interests'] = [];
+            return $response;
+        }
+        $response = buildResponseArray('personal_interests');
         $interestEntity = InterestEntity::where([
             ['entities_id', '=' , $user->user_id],
             ['expertise_id', 'like', 'personal%'],
@@ -179,8 +193,15 @@ class InterestsController extends Controller
      */
     public function getPersonsTeachingInterests($email)
     {
-        $user = User::whereEmail($email)->firstOrFail();
-        $response = buildResponseArray('interests');
+        $user = User::whereEmail($email)->first();
+        if($user==null)
+        {
+            $response = buildResponseArray('academic_interests');
+            $response['count']=0;
+            $response['interests'] = [];
+            return $response;
+        }
+        $response = buildResponseArray('academic_interests');
         $interests = Teaching::where('expertise_id', 'LIKE','%academic%')->where('entities_id', $user->user_id)->get();
         $idarray=[];
         foreach($interests as $interest) {

--- a/app/Http/Controllers/InterestsController.php
+++ b/app/Http/Controllers/InterestsController.php
@@ -129,15 +129,14 @@ class InterestsController extends Controller
     public function getPersonsResearchInterests($email)
     {
         $user = User::whereEmail($email)->first();
+        $response = buildResponseArray('research_interests');
         if($user==null)
         {
-            $response = buildResponseArray('research_interests');
-            $response['count']=0;
+
+            $response['count']='0';
             $response['interests'] = [];
             return $response;
         }
-
-        $response = buildResponseArray('research_interests');
 
         $interestEntity = InterestEntity::where('entities_id', $user->user_id)->get();
 
@@ -162,14 +161,13 @@ class InterestsController extends Controller
     public function getPersonsPersonalInterests($email)
     {
         $user = User::whereEmail($email)->first();
+        $response = buildResponseArray('personal_interests');
         if($user==null)
         {
-            $response = buildResponseArray('personal_interests');
-            $response['count']=0;
+            $response['count']='0';
             $response['interests'] = [];
             return $response;
         }
-        $response = buildResponseArray('personal_interests');
         $interestEntity = InterestEntity::where([
             ['entities_id', '=' , $user->user_id],
             ['expertise_id', 'like', 'personal%'],
@@ -194,17 +192,17 @@ class InterestsController extends Controller
     public function getPersonsTeachingInterests($email)
     {
         $user = User::whereEmail($email)->first();
+        $response = buildResponseArray('academic_interests');
         if($user==null)
         {
-            $response = buildResponseArray('academic_interests');
-            $response['count']=0;
+            $response['count']='0';
             $response['interests'] = [];
             return $response;
         }
-        $response = buildResponseArray('academic_interests');
         $interests = Teaching::where('expertise_id', 'LIKE','%academic%')->where('entities_id', $user->user_id)->get();
         $idarray=[];
-        foreach($interests as $interest) {
+        foreach($interests as $interest)
+        {
             $interest->expertise_id = substr($interest->expertise_id, 0, -9);
             $idarray[$interest->expertise_id]=$interest->expertise_id;
         }


### PR DESCRIPTION

Currently the look-ups for a person in each of the methods for personal, research, and academic/teaching uses a firsOrFail(). We want to change this to a first() instead.

We then want to check to see if first is empty and return an empty research collection, otherwise the code stays the same.

This task is done when I can run a search for nr_luis.guzman@csun.edu and I get an empty collection in the following format
{ "success": "true", "status": 200, "api": "affinity", "version": "1.0", "collection": "interests", "count": "0", "interests": [}

}


Currently in the JSON header we have a key called collection that returns the collection type. For all the interest types just simply return interests. It is better served to everyone if it returned the actual interest type:

research_interests
personal_interests
academic_interests

This task is done when the JSON header returns what the actual collection is.