### PR TITLE
ENG: All interests retrieval filtered by user.

### DIFF
--- a/app/Http/Controllers/InterestsController.php
+++ b/app/Http/Controllers/InterestsController.php
@@ -85,8 +85,13 @@ class InterestsController extends Controller
         $interestEntity = InterestEntity::where('entities_id',$user->user_id)->get();
         if(count($interestEntity)) {
             foreach($interestEntity as $item)
-                $researchId[] = $item->expertise_id;
-            $interests = Interest::findOrFail($researchId);
+                if(strpos($item->expertise_id, 'academic') !== false){
+                    $researchId[] = substr($item->expertise_id, 0,-9);
+                }else{
+                    $researchId[] = $item->expertise_id;
+                }
+            $interests = Interest::find($researchId);
+
         } else {
             $interests = $interestEntity;
         }


### PR DESCRIPTION
The function now handles cases in which a user has a research interest that is also an academic interest.  Example: "research:1303:academic" from fresco.expertise.entity.  This was the cause of the function not working.