### PR TITLE
AFFINITY-60 ENG: Remove the if check and string manipulation

### DIFF
--- a/app/Http/Controllers/BadgesController.php
+++ b/app/Http/Controllers/BadgesController.php
@@ -46,8 +46,6 @@ class BadgesController extends Controller
      */
     public function getPersonsBadges($email)
     {
-        if(str_contains($email, 'nr_'))
-            $email = str_replace('nr_', '', $email);
         $response = buildResponseArray('badges');
         $user = BadgeAwarded::email($email)->get();
         $response['count'] = "{$user->count()}";


### PR DESCRIPTION
Currently in the {code}getPersonsBadges($email){code} method there is an if check occurring and a corresponding string manipulation.

We want to get rid of this.

This task is done when
* The code is removed
* Consequently badges look up will not work.