### PR TITLE
Affinity 62 - Remove the route that accepts the email parameter in the URI

### DIFF
--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -15,7 +15,6 @@ $app->get('/', function () {
 $app->group(['prefix' => '/1.0', 'namespace' => 'App\Http\Controllers'], function() use ($app) {
     // Badge requests
     $app->get('badges', 'BadgesController@getAllBadges');
-    $app->get('badges/{email}', 'BadgesController@getPersonsBadges');
 
     // Interest requests
     $app->get('interests', 'InterestsController@getAllInterests');

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -13,7 +13,7 @@ $app->get('/', function () {
 });
 
 $app->group(['prefix' => '/1.0', 'namespace' => 'App\Http\Controllers'], function() use ($app) {
-    // Badge requests
+    // Badge request
     $app->get('badges', 'BadgesController@getAllBadges');
 
     // Interest requests

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -155,7 +155,6 @@
         <h2 id="subcollections" class="type--header type--thin">Subcollections</h2>
         <strong>Specified person's Badges</strong>
         <ul>
-          <li><a href="{{url('1.0/badges/'.$email['alexandra'])}}">{{url('1.0/badges/'.$email['alexandra'])}}</a></li>
           <li><a href="{{url('1.0/badges?email='.$email['alexandra'])}}">{{url('1.0/badges?email='.$email['alexandra'])}}</a></li>
         </ul>
         <strong>Specified person's Interests</strong>


### PR DESCRIPTION
## Problem
Remove the route that accepts an email parameter, as well as remove the link on the front end.

## Solution
- Deleted route in routes.php
- Deleted route in home.blade