### PR TITLE
testing/AFFINITY-76  Write PHPUnit test for: BadgesController@checkIfBadgeNameExists

### DIFF
--- a/tests/BadgesControllerTest.php
+++ b/tests/BadgesControllerTest.php
@@ -10,7 +10,7 @@ class BadgesControllerTest extends TestCase
         $this->assertEquals(true, $data);
     }
 
-    public function testCheckIfBadgeNameExists_throws_BadRequestHttpException(){
+    public function testCheckIfBadgeNameExists_throws_NotFoundHttpException(){
         $badgesController = new BadgesController;
         $this->setExpectedException(NotFoundHttpException::class);
         $badgesController->checkIfBadgeNameExists('A non-existent badge name');


### PR DESCRIPTION
### `testing/AFFINITY-76` - `PR`
`**READY**`

### Migrations
`NO'

### What's this PR do?
`This PR tests the output for BadgesController@checkIfBadgeNameExists.  There are two possible outputs that correspond to two functions.  First, an output can be true.  Secondly, the function described above can output a NotFoundHttpException.  Both of these cases are handled in tests/BadgesControllerTest.

This PR also effects the functionality of BadgesController@checkIfBadgeNameExists, before this function returned no value or an exception.  The code of the function was modified to return true or return an exception.  See below:

`public function checkIfBadgeNameExists($name){

        $badge = Badge::where('name', $name);
        if($badge->count() == 0){
            throw new BadRequestHttpException;
        }
        return true;  <---------Change is made here
    }`
### Where should the reviewer start?  
`All functionality in tests/BadgesControllerTest`

### Related PRs
`List related PRs against other branches:`

branch
------ | ------
`AFFINITY-76` | `https://github.com/csun-metalab/affinity/tree/AFFINITY-76`

### Steps to Test or Reproduce
'vendor/bin/phpunit'

### Impacted Areas in Application
BadgesController@checkIfBadgeNameExists
tests/BadesControllerTest 
